### PR TITLE
Rename zmplhelper subcommands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Then send it as a full replication stream to the receiving host.
 
     'zfs list' in the last line can be replaced with the zmplhelper utility.
     ```
-    repl@r$ zmplhelper list_ds -r backup/data | sudo xargs -n1 zfs mount
+    repl@r$ zmplhelper list dataset -r backup/data | sudo xargs -n1 zfs mount
     ```
 
     Optionally, you can make the datasets readonly to keep someone from accidentally changing their contents.
@@ -133,9 +133,9 @@ zmplrepl [-h]
 
 ### zmplhelper
 ```
-zmplhelper zfs_recv PARAMETERS...
-zmplhelper list_snap DATASET
-zmplhelper list_ds [-r] DATASET
+zmplhelper recv PARAMETERS...
+zmplhelper list snapshot [-l]  DATASET
+zmplhelper list dataset [-r] DATASET
 zmplhelper grant sender [-u USER] DATASET
 zmplhelper grant receiver [-u USER] DATASET
 ```

--- a/zmplhelper
+++ b/zmplhelper
@@ -9,27 +9,48 @@ echoerr() {
 
 usage_exit() {
 	echoerr "[USAGE]"
-	echoerr "$PROG zfs_recv PARAMETERS..."
-	echoerr "$PROG list_snap DATASET"
-	echoerr "$PROG list_ds [-r] DATASET"
+	echoerr "$PROG recv PARAMETERS..."
+	echoerr "$PROG list snapshot [-l] DATASET"
+	echoerr "$PROG list dataset [-r] DATASET"
 	echoerr "$PROG grant sender [-u USER] DATASET"
 	echoerr "$PROG grant receiver [-u USER] DATASET"
 	echoerr
 	exit 1
 }
 
-zfs_recv() {
+recv() {
 	zfs receive "$@"
 }
 
-list_snap() {
-	local ds=$1
-	if [ -n "$ds" ]; then
-		zfs list -o name -H -t snapshot -r "$ds" | fgrep "$ds@" | sed -e 's/.*@//'
+extract_snapshot_name() {
+	local longname=$1
+	if [ $longname -eq 0 ]; then
+		sed -e 's/.*@//'
+	else
+		cat
 	fi
 }
 
-list_ds() {
+list_snapshot() {
+	local OPTIND
+	local longname=0
+	while getopts "l" opt
+	do
+		case "$opt" in
+			l)
+				longname=1
+				;;
+		esac
+	done
+	shift $(( $OPTIND - 1 ))
+
+	local ds=$1
+	if [ -n "$ds" ]; then
+		zfs list -o name -H -t snapshot -r "$ds" | fgrep "$ds@" | extract_snapshot_name $longname
+	fi
+}
+
+list_dataset() {
 	local OPTIND
 	local recursive=0
 	while getopts "r" opt
@@ -129,15 +150,23 @@ cmd=$1
 shift
 
 case "$cmd" in
-	zfs_recv)
-		zfs_recv "$@"
+	recv)
+		recv "$@"
 		;;
-	list_snap)
-		ds=$1
-		list_snap "$ds"
-		;;
-	list_ds)
-		list_ds "$@"
+	list)
+		what=$1
+		shift
+		case "$what" in
+			snapshot)
+				list_snapshot "$@"
+				;;
+			dataset)
+				list_dataset "$@"
+				;;
+			*)
+				usage_exit
+				;;
+		esac
 		;;
 	grant)
 		grant "$@"

--- a/zmplrepl
+++ b/zmplrepl
@@ -114,7 +114,7 @@ u_list_snap() {
 	local host=$1
 	local ds=$2
 	if [ -n "$ds" ]; then
-		run_command -k "$SSHKEY" "$host" zmplhelper list_snap "$ds"
+		run_command -k "$SSHKEY" "$host" zmplhelper list snapshot "$ds"
 	fi
 }
 
@@ -127,7 +127,7 @@ u_list_ds() {
 		opts="-r"
 	fi
 	if [ -n "$ds" ]; then
-		run_command -k "$SSHKEY" "$host" zmplhelper list_ds $opts "$ds"
+		run_command -k "$SSHKEY" "$host" zmplhelper list dataset $opts "$ds"
 	fi
 }
 
@@ -143,7 +143,7 @@ u_zfs_recv() {
 	if [ -n "$DRYRUN" ]; then
 		cat
 	else
-		run_command -k "$SSHKEY" "$host" zmplhelper zfs_recv "$@"
+		run_command -k "$SSHKEY" "$host" zmplhelper recv "$@"
 	fi
 }
 


### PR DESCRIPTION
Rename the following subcommands.
- zfs_recv -> recv
- list_snap -> list snapshot
- list_ds -> list dataset